### PR TITLE
Add "new contributor" tag.

### DIFF
--- a/Guidelines.md
+++ b/Guidelines.md
@@ -12,6 +12,7 @@ Every [hapijs](https://github.com/hapijs) repository should make generous use of
 - `dependency` - if the issue or pull request addresses a dependency issue, it should have the `dependency` tag. Any module that is running in production should have a version >= 1.0.0 and all of it's dependencies should follow suite.
 - `discussion` - this tag gets applied to issues that are ideas or requests from the community that need active input from other community members and possibly the Lead Maintainer.
 - `enhancement` - non-breaking changes that would generally require a bump in the minor version number.
+- `new contributor` - tasks that are sufficiently small and easy for new contributors to complete, and which collaborators don't mind assisting new contributors in completing.
 - `non-issue` - this label is used when a user reports something that they perceive as a bug in a hapijs module but ultimately ends up being a user error. Often, issues tagged with `non-issue` will lead to updated documentation or additional validation.
 - `question` - generic label for user questions.
 - `release notes` - if the changes to a module are really broad, a new issue should be created and labeled with `release notes`. The issue should document what the changes are, how it impacts existing code and how to migrate to the next version.


### PR DESCRIPTION
I added a `new contributor` tag to the `makemehapi` repo and @chetandhembre suggested using it across the other Hapi projects in hapijs/discuss#2. I've added a description of the tag here in case we want to do that.
