### PR TITLE
Add sponsorship policy

### DIFF
--- a/Sponsorship.md
+++ b/Sponsorship.md
@@ -1,0 +1,31 @@
+# hapi.js Sponsorship Guidelines
+
+The hapi.js community consists of multiple modules, each with its own lead maintainer. The effort
+required to maintain a module can vary from a casual task a few hours a month to a time consuming
+effort which requires daily activity. This document describes the ways in which lead maintainers
+may obtain sponsorship for their effort or give proper credit to an employer supporting them.
+
+This policy is not a binding document but a list of best practices that if followed, will provide
+a consistent and fair handling of sponsorships across the hapi.js ecosystem.
+
+In most cases, a sponsorship recognizes the company employing the lead maintainer. However, lead
+maintainers may grant sponsorship spots to any company or organization they choose, and may do so
+in exchange for goods, services, or payment. If sponsorships are made available to entities other
+than the lead maintainer's employer, it should be done fairly and on an equal opportunity basis.
+
+A sponsorship package should include the following:
+* The sponsor name and logo with a short description and link on the module main README.md file.
+    * The logo should appear at the top of the document so it is visible on the module GitHub and
+      npm pages without scrolling.
+    * The company logo image size should not exceed 500x200px.
+    * The sponsorship section should be properly identified with "This module is sponsored by".
+* The sponsor name and logo listed on the hapi.js website under http://hapijs.com/sponsors.
+    * The page should include two sections, active sponsors at the top and alumni sponsors at the
+      bottom.
+    * No company should be listed more than once within each section.
+    * Each listing should mention the module or modules it is sponsoring.
+* A monthly tweet or retweet about the sponsorship on the @hapijs Twitter account.
+
+Module Sponsorships should be limited to:
+* Each module should only have one sponsor at a time.
+* A module should not have more than one sponsor a month on average.

--- a/Sponsorship.md
+++ b/Sponsorship.md
@@ -29,3 +29,11 @@ A sponsorship package should include the following:
 Module Sponsorships should be limited to:
 * Each module should only have one sponsor at a time.
 * A module should not have more than one sponsor a month on average.
+
+Lead maintainers seeking compensation in exchange for sponsorship should make sure they understand
+the legal and tax ramifications it may have. They are also encouraged to make any such transactions
+limited to the placement of the sponsor information on the README.md (since the rest of the above
+benefits require others to assist and may be outside the control of the lead maintainer). This will
+also remove potential issues in the future about copyright and other intellectual property claims
+by the sponsor (e.g making it clear that the sponsorship does not imply payment for any work on the
+module).


### PR DESCRIPTION
This document provides an outline for obtaining module sponsorship and giving recognition to companies supporting the hapi.js ecosystem. The goal is to provide a clear list of benefits and guidelines so that sponsorships are handled fairly and equally.