### PR TITLE
Add arrow function to "Empty line after `{`"

### DIFF
--- a/Style.md
+++ b/Style.md
@@ -292,6 +292,7 @@
   - Empty line after `{`
     - Following a multi-line condition
     - In function scope declarations
+    - In arrow function declarations
 
   ```javascript
   // Right

--- a/Style.md
+++ b/Style.md
@@ -292,7 +292,7 @@
   - Empty line after `{`
     - Following a multi-line condition
     - In function scope declarations
-    - In arrow function declarations
+    - In arrow function declarations using curly braces
 
   ```javascript
   // Right


### PR DESCRIPTION
Fix #70
